### PR TITLE
Fix coins not consistently giving coins to users

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -59,6 +59,10 @@ bot.addCommand('@givecoins <username> <amount>', async (ctx, args) => {
     }
 
     const twitchUser = await twitchApi.getUserByUsername(username);
+    if (!twitchUser) {
+        return bot.say(`No user with username ${username} found`);
+    }
+
     await setCoins(twitchUser, amount);
 });
 
@@ -70,6 +74,10 @@ bot.addCommand('@takecoins <username> <amount>', async (ctx, args) => {
     }
 
     const twitchUser = await twitchApi.getUserByUsername(username);
+    if (!twitchUser) {
+        return bot.say(`No user with username ${username} found`);
+    }
+
     await setCoins(twitchUser, -amount);
 });
 

--- a/src/services/twitch.service.js
+++ b/src/services/twitch.service.js
@@ -3,10 +3,7 @@ const devwarsApi = require('../apis/devwarsApi');
 
 async function giveCoinsToAllViewers(amount) {
     const usernames = await twitchApi.getViewers();
-
-    const twitchUsers = await Promise.all(
-        usernames.map(username => twitchApi.getUserByUsername(username)),
-    );
+    const twitchUsers = await twitchApi.getUsersByUsernames(usernames);
 
     const updates = twitchUsers.map(user => ({ user, amount }));
     return devwarsApi.putCoins(updates);


### PR DESCRIPTION
### Overview
Fixes issue where `!coinsall` command was not consistently giving coins to users.

#### Batching
Added `getUsersByUsernames` function to batch users in groups of 100 ([Twitch API Limit](https://dev.twitch.tv/docs/api/reference#get-users)) to send fewer requests in bulk. Previously, API was returning 429 (Too Many Requests) error causing the requests to be rejected.

### Notes
* Refactor `getViewers()` using `_.flatMapDeep()`
* Add error catching to `getUsersByUsernames`
* Add guards for user not found when giving/taking coins

### Related issues
[Fixes #11](https://github.com/DevWars/devwars-bot/issues/11)