### PR TITLE
Update help command frequency intervals to prevent overlaps

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -25,11 +25,11 @@ bot.addCommand('!watch', () => {
 
 bot.addCommand('!discord', () => {
     bot.say('Join our growing Discord community for developers by heading over to discord.gg/devwars');
-}, ms('10m'));
+}, ms('13m'));
 
 bot.addCommand('!follow', () => {
     bot.say('Enjoying DevWars? Hit the follow button so you don\'t miss another stream!');
-}, ms('15m'));
+}, ms('21m'));
 
 bot.addCommand('!coins', async (ctx) => {
     let userCoins = await devwarsApi.getCoins(ctx.user);


### PR DESCRIPTION
## Overview
Fixed issue where help commands were constantly coming in at the same time. This would cause the commands to feel a bit more randomized or spaced out. There is still a chance that these commands would line up at some point, but much less frequently.